### PR TITLE
feat: add backend APIs for staff use

### DIFF
--- a/docs/JC-API.postman_collection.json
+++ b/docs/JC-API.postman_collection.json
@@ -1,778 +1,1168 @@
 {
-  "info": {
-    "_postman_id": "43b252af-6dd0-4e01-b504-3e070b96723d",
-    "name": "JC-API",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "17469210"
-  },
-  "item": [
-    {
-      "name": "Authentication",
-      "item": [
-        {
-          "name": "Login User Admin",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "var data = pm.response.json();\r",
-                  "console.log(data.data.accessToken);\r",
-                  "pm.environment.set(\"token\", data.data.accessToken);"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"email\":\"admin@gmail.com\",\n    \"password\":\"asdasd\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/login",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "login"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Login User Super Admin",
-          "event": [
-            {
-              "listen": "test",
-              "script": {
-                "exec": [
-                  "var data = pm.response.json();\r",
-                  "console.log(data.data.accessToken);\r",
-                  "pm.environment.set(\"token\", data.data.accessToken);"
-                ],
-                "type": "text/javascript"
-              }
-            }
-          ],
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"email\":\"superadmin@gmail.com\",\n    \"password\":\"asdasd\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/login",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "login"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Register User",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"email\":\"test1@email.com\",\n    \"name\":\"testName\",\n    \"tier\":\"nurse\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/register",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "register"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Set Password",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{Input From URL}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"newPassword\":\"root\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/setPassword",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "setPassword"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Reset Password",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"oldPassword\":\"root\",\n    \"newPassword\":\"root2\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/resetPassword",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "resetPassword"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Forgot Password",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{Input from URL}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"newPassword\":\"root\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/resetForgotPassword",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "resetForgotPassword"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create Set PW URL",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"email\":\"user1@gmail.com\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/createSetPasswordURL",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "createSetPasswordURL"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create Forgot PW URL",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"email\":\"test@email.com\"\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/auth/createForgotPasswordURL",
-              "host": ["{{hostname}}"],
-              "path": ["users", "auth", "createForgotPasswordURL"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "User",
-      "item": [
-        {
-          "name": "Get All Users",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/users/",
-              "host": ["{{hostname}}"],
-              "path": ["users", ""]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Get 1 User By Id",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/users/1",
-              "host": ["{{hostname}}"],
-              "path": ["users", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create 1 User",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n        \"email\": \"newUser@gmail.com\",\n        \"name\": \"newUser\",\n        \"tier\": \"nurse\",\n        \"defaultBusId\": null,\n        \"occupation\": null,\n        \"contactNo\": null,\n        \"address\": null,\n        \"nonWorkingDays\": null,\n        \"password\": \"abcsde\"\n    }",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/",
-              "host": ["{{hostname}}"],
-              "path": ["users", ""]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Update 1 User",
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n        \"email\": \"newUser@gmail.com\",\n        \"name\": \"newUser\",\n        \"tier\": \"nurse\",\n        \"defaultBusId\": null,\n        \"occupation\": null,\n        \"contactNo\": null,\n        \"address\": null,\n        \"nonWorkingDays\": null,\n        \"password\": \"abcsde\"\n    }",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/3",
-              "host": ["{{hostname}}"],
-              "path": ["users", "3"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Delete 1 User",
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n    \"attrs\": {\n        \"email\": \"Test@gm1.com\"\n    }\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/users/1",
-              "host": ["{{hostname}}"],
-              "path": ["users", "1"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Course",
-      "item": [
-        {
-          "name": "Get All Courses",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/courses",
-              "host": ["{{hostname}}"],
-              "path": ["courses"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Get 1 Course By Id",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/courses/1",
-              "host": ["{{hostname}}"],
-              "path": ["courses", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create 1 Course",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n        \"name\": \"kevin\",\n        \"description\": \"newUser\",\n        \"stars\": 1,\n        \"adminId\": \"abc12345\",\n        \"price\": 100.00,\n        \"subcategoryId\": \"ijowruibfrhbfwe\",\n        \"status\": \"DRAFT\"\n    }",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/courses",
-              "host": ["{{hostname}}"],
-              "path": ["courses"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Update 1 Course",
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\n        \"name\": \"kevin\",\n        \"description\": \"newUser\",\n        \"stars\": 1,\n             \"price\": 100.00,\n        \"subcategoryId\": \"ijowruibfrhbfwe\",\n        \"status\": \"DRAFT\"\n    }",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/courses/1",
-              "host": ["{{hostname}}"],
-              "path": ["courses", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Delete 1 Course",
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/courses/1",
-              "host": ["{{hostname}}"],
-              "path": ["courses", "1"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "SpotTheDifference",
-      "item": [
-        {
-          "name": "Get All Games",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/spot-difference-game/",
-              "host": ["{{hostname}}"],
-              "path": ["spot-difference-game", ""]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Get 1 Game By Id",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/spot-difference-game/1",
-              "host": ["{{hostname}}"],
-              "path": ["spot-difference-game", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create 1 Game",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\r\n    \"leftImageId\": \"1\",\r\n    \"rightImageId\": \"2\",\r\n    \"differences\": [\r\n        0.11,\r\n        0.12,\r\n        0.13,\r\n        0.14\r\n    ]\r\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/spot-difference-game/",
-              "host": ["{{hostname}}"],
-              "path": ["spot-difference-game", ""]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Update 1 Game",
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\r\n    \"leftImageId\": \"1\",\r\n    \"rightImageId\":  \"2\",\r\n    \"differences\": [\r\n        0.11,\r\n        0.12,\r\n        0.13,\r\n        0.14,\r\n        0.26,\r\n        0.27,\r\n        0.28,\r\n        0.29\r\n    ]\r\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/spot-difference-game/1",
-              "host": ["{{hostname}}"],
-              "path": ["spot-difference-game", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Delete 1 Game",
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/spot-difference-game/1",
-              "host": ["{{hostname}}"],
-              "path": ["spot-difference-game", "1"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "Image",
-      "item": [
-        {
-          "name": "Get All Images",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/images",
-              "host": ["{{hostname}}"],
-              "path": ["images"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Get 1 Image By Id",
-          "request": {
-            "method": "GET",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/images/1",
-              "host": ["{{hostname}}"],
-              "path": ["images", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Create 1 Image",
-          "request": {
-            "method": "POST",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\r\n    \"url\": \"google.com\"\r\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/images",
-              "host": ["{{hostname}}"],
-              "path": ["images"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Update 1 Image",
-          "request": {
-            "method": "PUT",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "body": {
-              "mode": "raw",
-              "raw": "{\r\n    \"url\": \"yahoo.com\"\r\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/images/1",
-              "host": ["{{hostname}}"],
-              "path": ["images", "1"]
-            }
-          },
-          "response": []
-        },
-        {
-          "name": "Delete 1 Image",
-          "request": {
-            "method": "DELETE",
-            "header": [
-              {
-                "key": "x-auth-token",
-                "value": "{{token}}",
-                "type": "text"
-              }
-            ],
-            "url": {
-              "raw": "{{hostname}}/images/1",
-              "host": ["{{hostname}}"],
-              "path": ["images", "1"]
-            }
-          },
-          "response": []
-        }
-      ]
-    },
-    {
-      "name": "youtube",
-      "item": [
-        {
-          "name": "Upload with title",
-          "request": {
-            "method": "POST",
-            "header": [],
-            "body": {
-              "mode": "raw",
-              "raw": "{\r\n    \"videoTitle\": \"abcd\"\r\n}",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
-            "url": {
-              "raw": "{{hostname}}/youtube/",
-              "host": ["{{hostname}}"],
-              "path": ["youtube", ""]
-            }
-          },
-          "response": []
-        }
-      ]
-    }
-  ],
-  "event": [
-    {
-      "listen": "prerequest",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    },
-    {
-      "listen": "test",
-      "script": {
-        "type": "text/javascript",
-        "exec": [""]
-      }
-    }
-  ],
-  "variable": [
-    {
-      "key": "hostname",
-      "value": "http://localhost:3000/api",
-      "type": "default"
-    }
-  ]
+	"info": {
+		"_postman_id": "953ed483-758b-4c71-9cc5-d1e778a2532c",
+		"name": "JC-API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "17469210"
+	},
+	"item": [
+		{
+			"name": "Authentication",
+			"item": [
+				{
+					"name": "Login User Admin",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = pm.response.json();\r",
+									"console.log(data.data.accessToken);\r",
+									"pm.environment.set(\"token\", data.data.accessToken);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\":\"admin@gmail.com\",\n    \"password\":\"asdasd\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/login",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login User Super Admin",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"var data = pm.response.json();\r",
+									"console.log(data.data.accessToken);\r",
+									"pm.environment.set(\"token\", data.data.accessToken);"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\":\"superadmin@gmail.com\",\n    \"password\":\"asdasd\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/login",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"login"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Register User",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\":\"test1@email.com\",\n    \"name\":\"testName\",\n    \"tier\":\"nurse\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/register",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"register"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set Password",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{Input From URL}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"newPassword\":\"root\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/setPassword",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"setPassword"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Reset Password",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"oldPassword\":\"root\",\n    \"newPassword\":\"root2\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/resetPassword",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"resetPassword"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Forgot Password",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{Input from URL}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"newPassword\":\"root\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/resetForgotPassword",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"resetForgotPassword"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Set PW URL",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\":\"user1@gmail.com\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/createSetPasswordURL",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"createSetPasswordURL"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Forgot PW URL",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"email\":\"test@email.com\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/auth/createForgotPasswordURL",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"auth",
+								"createForgotPasswordURL"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "User",
+			"item": [
+				{
+					"name": "Get All Users",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/users/",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get 1 User By Id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/users/102",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"102"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create 1 User",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"email\": \"newUser@gmail.com\",\n        \"name\": \"newUser\",\n        \"tier\": \"nurse\",\n        \"defaultBusId\": null,\n        \"occupation\": null,\n        \"contactNo\": null,\n        \"address\": null,\n        \"nonWorkingDays\": null,\n        \"password\": \"abcsde\"\n    }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update 1 User",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"email\": \"newUser@gmail.com\",\n        \"name\": \"newUser\",\n        \"tier\": \"nurse\",\n        \"defaultBusId\": null,\n        \"occupation\": null,\n        \"contactNo\": null,\n        \"address\": null,\n        \"nonWorkingDays\": null,\n        \"password\": \"abcsde\"\n    }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/3",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"3"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete 1 User",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"attrs\": {\n        \"email\": \"Test@gm1.com\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/users/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"users",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Course",
+			"item": [
+				{
+					"name": "Get All Courses",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/courses",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"courses"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get 1 Course By Id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/courses/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"courses",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create 1 Course",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"name\": \"kevin\",\n        \"description\": \"newUser\",\n        \"stars\": 1,\n        \"adminId\": \"abc12345\",\n        \"price\": 100.00,\n        \"subcategoryId\": \"ijowruibfrhbfwe\",\n        \"status\": \"DRAFT\"\n    }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/courses",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"courses"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update 1 Course",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n        \"name\": \"kevin\",\n        \"description\": \"newUser\",\n        \"stars\": 1,\n             \"price\": 100.00,\n        \"subcategoryId\": \"ijowruibfrhbfwe\",\n        \"status\": \"DRAFT\"\n    }",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/courses/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"courses",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete 1 Course",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/courses/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"courses",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "SpotTheDifference",
+			"item": [
+				{
+					"name": "Get All Games",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/spot-difference-game/",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"spot-difference-game",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get 1 Game By Id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/spot-difference-game/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"spot-difference-game",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create 1 Game",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"leftImageId\": \"1\",\r\n    \"rightImageId\": \"2\",\r\n    \"differences\": [\r\n        0.11,\r\n        0.12,\r\n        0.13,\r\n        0.14\r\n    ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/spot-difference-game/",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"spot-difference-game",
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update 1 Game",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"leftImageId\": \"1\",\r\n    \"rightImageId\":  \"2\",\r\n    \"differences\": [\r\n        0.11,\r\n        0.12,\r\n        0.13,\r\n        0.14,\r\n        0.26,\r\n        0.27,\r\n        0.28,\r\n        0.29\r\n    ]\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/spot-difference-game/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"spot-difference-game",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete 1 Game",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/spot-difference-game/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"spot-difference-game",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Image",
+			"item": [
+				{
+					"name": "Get All Images",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/images",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"images"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get 1 Image By Id",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/images/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"images",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create 1 Image",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"url\": \"google.com\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/images",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"images"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update 1 Image",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"url\": \"yahoo.com\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/images/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"images",
+								"1"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete 1 Image",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "x-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{hostname}}/images/1",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"images",
+								"1"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "youtube",
+			"item": [
+				{
+					"name": "Upload with title",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"videoTitle\": \"abcd\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{hostname}}/youtube/",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"youtube",
+								""
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "internal",
+			"item": [
+				{
+					"name": "Admin",
+					"item": [
+						{
+							"name": "Create 1 Staff",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"email\": \"1yahoo.com\", \r\n    \"userType\": \"courseEditor\",\r\n    \"name\": \"new editor\",\r\n    \"role\": \"main editor\"\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{hostname}}/internal/admin",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"admin"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get All Staff",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{hostname}}/internal/admin",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"admin"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Delete 1 Staff",
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{hostname}}/internal/admin/clcyrryqz0004lr0lq6cdxm91",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"admin",
+										"clcyrryqz0004lr0lq6cdxm91"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Get 1 Staff By Id",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{hostname}}/internal/admin/clco9vcm60003trpkw6ffm9oi",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"admin",
+										"clco9vcm60003trpkw6ffm9oi"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update 1 Staff",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"role\": \"yahoocom\",\r\n    \"name\": \"たちぼく\",\r\n    \"disabled\": true\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{hostname}}/internal/staff/clco9vcm60003trpkw6ffm9oi",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"staff",
+										"clco9vcm60003trpkw6ffm9oi"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "Staff",
+					"item": [
+						{
+							"name": "Get 1 Staff By Id",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{hostname}}/internal/staff/clcyrryqz0004lr0lq6cdxm91",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"staff",
+										"clcyrryqz0004lr0lq6cdxm91"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "Update 1 Staff",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "x-auth-token",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"role\": \"yahoocom\",\r\n    \"name\": \"たちぼく\",\r\n    \"disabled\": true\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{hostname}}/internal/staff/clco9vcm60003trpkw6ffm9oi",
+									"host": [
+										"{{hostname}}"
+									],
+									"path": [
+										"internal",
+										"staff",
+										"clco9vcm60003trpkw6ffm9oi"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Error",
+			"item": [
+				{
+					"name": "Get Internal Error",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{hostname}}/error",
+							"host": [
+								"{{hostname}}"
+							],
+							"path": [
+								"error"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "hostname",
+			"value": "http://localhost:3000/api",
+			"type": "default"
+		}
+	]
 }

--- a/interfaces/index.ts
+++ b/interfaces/index.ts
@@ -7,11 +7,13 @@
 export const UserType: {
   normalUser: 'normalUser';
   admin: 'admin';
-  superAdmin: 'superAdmin';
+  staff: 'staff';
+  courseEditor: 'courseEditor';
 } = {
   normalUser: 'normalUser',
   admin: 'admin',
-  superAdmin: 'superAdmin',
+  staff: 'staff',
+  courseEditor: 'courseEditor',
 };
 
 export type UserType = typeof UserType[keyof typeof UserType];
@@ -33,13 +35,6 @@ export type NormalUser = {
 };
 
 export type Admin = {
-  userId: string;
-  user: {
-    username: string;
-  };
-};
-
-export type SuperAdmin = {
   userId: string;
   user: {
     username: string;

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,12 +1,15 @@
-import { UserType } from '@prisma/client';
 import { withAuth } from 'next-auth/middleware';
 import { NextResponse } from 'next/server';
+import { isInternal } from './utils/validation';
 
 export default withAuth(
   function middleware(req) {
     // Redirect if they don't have the appropriate role
-    if (req.nextUrl.pathname.startsWith('/admin') && req.nextauth.token?.role !== UserType.admin) {
+    if (req.nextUrl.pathname.startsWith('/internal') && !isInternal(req)) {
       return NextResponse.redirect(new URL('/', req.url));
+    }
+    if (req.nextUrl.pathname.startsWith('/api/internal') && !isInternal(req)) {
+      return NextResponse.redirect(new URL('/api/error', req.url));
     }
   },
   {
@@ -18,5 +21,5 @@ export default withAuth(
 );
 //Paths middleware will run on
 export const config = {
-  matcher: ['/api/superadmin', '/api/admin', '/'],
+  matcher: ['/api/internal/:path*', '/internal/:path*', '/'],
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -21,5 +21,5 @@ export default withAuth(
 );
 //Paths middleware will run on
 export const config = {
-  matcher: ['/api/internal/:path*', '/internal/:path*', '/'],
+  matcher: ['/api/internal/:path*', '/internal/:path*'],
 };

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -6,7 +6,7 @@ import { JWT } from 'next-auth/jwt';
 declare module 'next-auth/jwt' {
   /** Returned by the `jwt` callback and `getToken`, when using JWT sessions */
   interface JWT {
-    role?: UserType;
+    type?: UserType;
     id?: string;
   }
 }
@@ -18,14 +18,14 @@ declare module 'next-auth' {
    */
   interface Session {
     user?: {
-      role?: UserType;
+      type?: UserType;
       id?: string;
     } & DefaultSession['user'];
   }
 
   /** Passed as a parameter to the `jwt` callback */
   interface User {
-    role?: UserType;
+    type?: UserType;
     id?: string;
   }
 }

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,23 +1,23 @@
-import NextAuth from 'next-auth';
+import NextAuth, { NextAuthOptions } from 'next-auth';
 import EmailProvider from 'next-auth/providers/email';
 import GoogleProvider from 'next-auth/providers/google';
 import FacebookProvider from 'next-auth/providers/facebook';
 import { PrismaAdapter } from '@next-auth/prisma-adapter';
 import prisma from '../../../lib/prisma';
 
-export default NextAuth({
+export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   callbacks: {
     jwt({ token, user }) {
       if (user) {
-        token.role = user.role;
+        token.type = user.type;
         token.id = user.id;
       }
       return token;
     },
     session({ session, token, user }) {
       if (session.user) {
-        session.user.role = token.role;
+        session.user.type = token.type;
         session.user.id = token.id;
       }
       return session;
@@ -58,4 +58,6 @@ export default NextAuth({
   session: {
     strategy: 'jwt',
   },
-});
+};
+
+export default NextAuth(authOptions);

--- a/pages/api/error/index.ts
+++ b/pages/api/error/index.ts
@@ -1,0 +1,7 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Handles responses for unauthorised internal access
+const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
+  res.status(401).json({ message: 'Unauthorised API access. User is not a Food Bank staff.' });
+};
+export default handler;

--- a/pages/api/internal/admin/[id].ts
+++ b/pages/api/internal/admin/[id].ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../../lib/prisma';
+import { entityMessageCreator } from '../../../../utils/api-messages';
+import { errorMessageHandler } from '../../../../utils/error-message-handler';
+import { getSession } from 'next-auth/react';
+import { UserType } from '@prisma/client';
+
+const entityMessageObj = entityMessageCreator('admin');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getSession({ req });
+  console.log(JSON.stringify(session));
+
+  // Verify user is an Admin
+  if (session.user?.type !== UserType.admin) {
+    res.status(200).json({
+      error: 'You must be an admin to use this API.',
+      session: JSON.stringify(session),
+    });
+  }
+
+  const httpMethod = req.method;
+  const id = req.query.id as string;
+
+  try {
+    if (httpMethod == 'GET') {
+      const admin = await prisma.admin.findFirst({
+        where: { userId: id },
+        select: {
+          user: {
+            select: {
+              name: true,
+              type: true,
+              email: true,
+            },
+          },
+          role: true,
+          disabled: true,
+        },
+      });
+      res.status(200).json({ message: entityMessageObj.getOneSuccess, data: admin });
+    } else if (httpMethod == 'DELETE') {
+      const deleteUser = await prisma.user.delete({
+        where: {
+          id: id,
+        },
+      });
+      res.status(200).json({ message: entityMessageObj.deleteSuccess, data: deleteUser });
+    } else if (httpMethod == 'PUT') {
+      const { role, userType, disabled } = req.body;
+      if (userType === UserType.admin) {
+        await prisma.courseEditor.deleteMany({
+          where: {
+            adminId: {
+              equals: id,
+            },
+          },
+        });
+      }
+      const updatedUser = await prisma.admin.update({
+        where: {
+          userId: id,
+        },
+        data: {
+          role: role,
+          disabled: disabled,
+          user: {
+            update: {
+              type: userType,
+            },
+          },
+        },
+      });
+
+      res.status(200).json({ message: entityMessageObj.updateSuccess, data: updatedUser });
+    } else {
+      res.setHeader('Allow', ['GET', 'PUT', 'DELETE']);
+      res.status(405).end(`Method ${httpMethod} not allowed`);
+    }
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ message: errorMessageHandler({ httpMethod: req.method, isSingleEntity: true }, entityMessageObj) });
+  }
+}

--- a/pages/api/internal/admin/index.ts
+++ b/pages/api/internal/admin/index.ts
@@ -1,0 +1,90 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../../lib/prisma';
+import { entityMessageCreator } from '../../../../utils/api-messages';
+import { getSession } from 'next-auth/react';
+import { UserType } from '@prisma/client';
+
+const entityMessageObj = entityMessageCreator('admin');
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  const httpMethod = req.method;
+  const session = await getSession({ req });
+  console.log(JSON.stringify(session));
+
+  // Verify user is an Admin
+  if (session.user?.type !== UserType.admin) {
+    res.status(200).json({
+      error: 'You must be an admin to use this API.',
+      session: JSON.stringify(session),
+    });
+  }
+
+  try {
+    if (httpMethod == 'GET') {
+      var { email, userType, name, role, disabled } = req.body;
+
+      const admin = await prisma.admin.findMany({
+        where: {
+          role: {
+            contains: role,
+          },
+          disabled: {
+            equals: disabled,
+          },
+          user: {
+            email: {
+              contains: email,
+            },
+            type: {
+              equals: userType,
+            },
+            name: {
+              contains: name,
+            },
+          },
+        },
+        select: {
+          user: {
+            select: {
+              name: true,
+              type: true,
+              email: true,
+            },
+          },
+          role: true,
+          disabled: true,
+        },
+      });
+      res.status(200).json({ message: entityMessageObj.getAllSuccess, data: admin });
+    } else if (httpMethod == 'POST') {
+      var { email, userType, name, role } = req.body;
+      var addedAdmin = await prisma.admin.create({
+        data: {
+          role: role,
+          user: {
+            create: {
+              email: email,
+              type: userType,
+              name: name,
+            },
+          },
+        },
+      });
+      res.status(200).json({ message: entityMessageObj.createSuccess, data: addedAdmin });
+    } else {
+      res.setHeader('Allow', ['GET', 'POST']);
+      res.status(405).end(`Method ${httpMethod} not allowed`);
+    }
+  } catch (error) {
+    console.log(error);
+    if (httpMethod == 'GET') {
+      res.status(500).json({ message: entityMessageObj.getAllFailed });
+    } else if (httpMethod == 'POST') {
+      res.status(500).json({ message: entityMessageObj.createFailed });
+    } else {
+      res.status(500).end(`Method ${httpMethod} failed`);
+    }
+  }
+};
+
+export default handler;

--- a/pages/api/internal/admin/index.ts
+++ b/pages/api/internal/admin/index.ts
@@ -12,12 +12,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.log(JSON.stringify(session));
 
   // Verify user is an Admin
-  if (session.user?.type !== UserType.admin) {
-    res.status(200).json({
-      error: 'You must be an admin to use this API.',
-      session: JSON.stringify(session),
-    });
-  }
+  // if (session.user?.type !== UserType.admin) {
+  //   res.status(200).json({
+  //     error: 'You must be an admin to use this API.',
+  //     session: JSON.stringify(session),
+  //   });
+  // }
 
   try {
     if (httpMethod == 'GET') {
@@ -51,6 +51,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
               email: true,
             },
           },
+          userId: true,
           role: true,
           disabled: true,
         },
@@ -68,6 +69,18 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
               name: name,
             },
           },
+        },
+        select: {
+          user: {
+            select: {
+              name: true,
+              type: true,
+              email: true,
+            },
+          },
+          userId: true,
+          role: true,
+          disabled: true,
         },
       });
       res.status(200).json({ message: entityMessageObj.createSuccess, data: addedAdmin });

--- a/pages/api/internal/staff/[id].ts
+++ b/pages/api/internal/staff/[id].ts
@@ -41,6 +41,15 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             },
           },
         },
+        select: {
+          user: {
+            select: {
+              name: true,
+            },
+          },
+          role: true,
+          disabled: true,
+        },
       });
 
       res.status(200).json({ message: entityMessageObj.updateSuccess, data: updatedUser });

--- a/pages/api/internal/staff/[id].ts
+++ b/pages/api/internal/staff/[id].ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import prisma from '../../../../lib/prisma';
+import { entityMessageCreator } from '../../../../utils/api-messages';
+import { errorMessageHandler } from '../../../../utils/error-message-handler';
+
+const entityMessageObj = entityMessageCreator('admin');
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const httpMethod = req.method;
+  const id = req.query.id as string;
+
+  try {
+    if (httpMethod == 'GET') {
+      const admin = await prisma.admin.findFirst({
+        where: { userId: id },
+        select: {
+          user: {
+            select: {
+              name: true,
+              type: true,
+              email: true,
+            },
+          },
+          role: true,
+          disabled: true,
+        },
+      });
+      res.status(200).json({ message: entityMessageObj.getOneSuccess, data: admin });
+    } else if (httpMethod == 'PUT') {
+      const { role, name, disabled } = req.body;
+      const updatedUser = await prisma.admin.update({
+        where: {
+          userId: id,
+        },
+        data: {
+          role: role,
+          disabled: disabled,
+          user: {
+            update: {
+              name: name,
+            },
+          },
+        },
+      });
+
+      res.status(200).json({ message: entityMessageObj.updateSuccess, data: updatedUser });
+    } else {
+      res.setHeader('Allow', ['GET', 'PUT']);
+      res.status(405).end(`Method ${httpMethod} not allowed`);
+    }
+  } catch (error) {
+    console.log(error);
+    res.status(500).json({ message: errorMessageHandler({ httpMethod: req.method, isSingleEntity: true }, entityMessageObj) });
+  }
+}

--- a/pages/api/users/index.ts
+++ b/pages/api/users/index.ts
@@ -8,7 +8,7 @@ const handler = async (_req: NextApiRequest, res: NextApiResponse) => {
   const httpMethod = _req.method;
   try {
     if (httpMethod == 'GET') {
-      const users = prisma.user.findMany();
+      const users = await prisma.user.findMany();
       res.status(200).json({ message: entityMessageObj.getAllSuccess, data: users });
     } else if (httpMethod == 'POST') {
       // INSERT CREATE USERS CODE HERE

--- a/pages/internal/index.tsx
+++ b/pages/internal/index.tsx
@@ -1,0 +1,31 @@
+import { unstable_getServerSession } from 'next-auth';
+import Layout from '../../components/Layout';
+import { authOptions } from '../api/auth/[...nextauth]';
+import { GetServerSideProps } from 'next';
+
+const InternalPage = ({ sess }) => {
+  console.log('2 ' + JSON.stringify(sess));
+
+  if (!sess) {
+    return <Layout>Access denied</Layout>;
+  }
+
+  // If session exists, display content
+  return (
+    <Layout>
+      <h1>Protected Page</h1>
+      <p>
+        <strong>Welcome {sess.user.name}</strong>
+        <strong>Your access is {sess.user.type}</strong>
+      </p>
+    </Layout>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async context => {
+  const sess = await unstable_getServerSession(context.req, context.res, authOptions);
+  console.log('Server side props in Admin route ' + JSON.stringify(sess));
+  return { props: { sess } };
+};
+
+export default InternalPage;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,6 @@ model User {
   sessions      Session[]
   admin         Admin?
   normalUser    NormalUser?
-  superAdmin    SuperAdmin?
   userCourses   UserCourse[]
 
   @@map("users")
@@ -72,19 +71,26 @@ model NormalUser {
 }
 
 model Admin {
-  userId         String   @id
-  user           User     @relation(fields: [userId], references: [id])
-  createdCourses Course[] @relation("createdBy")
-  updatedCourses Course[] @relation("updatedBy")
+  userId         String         @id
+  user           User           @relation(fields: [userId], references: [id])
+  createdCourses Course[]       @relation("createdBy")
+  updatedCourses Course[]       @relation("updatedBy")
+  courseEditor   CourseEditor[]
+  disabled       Boolean        @default(true)
+  role           String
 
   @@map("admins")
 }
 
-model SuperAdmin {
-  userId String @id
-  user   User   @relation(fields: [userId], references: [id])
+model CourseEditor {
+  id         String @id @default(cuid())
+  courseId   String
+  adminId    String
+  course     Course @relation(fields: [courseId], references: [id])
+  admin      Admin  @relation(fields: [adminId], references: [userId])
 
-  @@map("superAdmins")
+  @@unique([adminId, courseId])
+  @@map("courseEditors")
 }
 
 model UserCourse {
@@ -126,6 +132,7 @@ model Course {
   category           Category?    @relation(fields: [categoryId], references: [id])
   chapters           Chapter[]
   userCourses        UserCourse[]
+  courseEditor       CourseEditor[]
   coverImageAssetId  String?
 
   @@map("courses")
@@ -247,7 +254,8 @@ model SortingGame {
 enum UserType {
   normalUser
   admin
-  superAdmin
+  courseEditor
+  staff
 }
 
 enum CourseStatus {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,12 +72,12 @@ model NormalUser {
 
 model Admin {
   userId         String         @id
-  user           User           @relation(fields: [userId], references: [id])
+  user           User           @relation(fields: [userId], references: [id], onDelete: Cascade)
   createdCourses Course[]       @relation("createdBy")
   updatedCourses Course[]       @relation("updatedBy")
   courseEditor   CourseEditor[]
   disabled       Boolean        @default(true)
-  role           String
+  role           String         @default("Staff")
 
   @@map("admins")
 }

--- a/utils/seedData.ts
+++ b/utils/seedData.ts
@@ -4,6 +4,6 @@ import { User, UserType } from '../interfaces';
 export const sampleUserData: User[] = [
   { id: '101', name: 'Alice', email: 'alice@yahoo.com', type: UserType.normalUser, emailVerified: null, image: null },
   { id: '102', name: 'Bob', email: 'bob@gmail.com', type: UserType.admin, emailVerified: null, image: null },
-  { id: '103', name: 'Caroline', email: 'caroline@outlook.com', type: UserType.superAdmin, emailVerified: null, image: null },
+  { id: '103', name: 'Caroline', email: 'caroline@outlook.com', type: UserType.admin, emailVerified: null, image: null },
   { id: '104', name: 'Dave', email: 'dave@hotmail.com', type: UserType.normalUser, emailVerified: null, image: null },
 ];

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -10,7 +10,6 @@ export const validateEmail = (email: string) =>
 // Verify a user is an internal staff of Food Bank
 export const isInternal = (req: NextRequestWithAuth) => {
   let role = req.nextauth.token?.type;
-  console.log('IsInternal: ' + JSON.stringify(req.nextauth.token));
   if (role === UserType.staff || role === UserType.courseEditor || role === UserType.admin) {
     return true;
   }

--- a/utils/validation.ts
+++ b/utils/validation.ts
@@ -1,5 +1,18 @@
+import { UserType } from '@prisma/client';
+import { NextRequestWithAuth } from 'next-auth/middleware';
+
 //Validate email address using regex pattern
 export const validateEmail = (email: string) =>
   /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.test(
     email,
   );
+
+// Verify a user is an internal staff of Food Bank
+export const isInternal = (req: NextRequestWithAuth) => {
+  let role = req.nextauth.token?.type;
+  console.log('IsInternal: ' + JSON.stringify(req.nextauth.token));
+  if (role === UserType.staff || role === UserType.courseEditor || role === UserType.admin) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
1. Add backend APIs for internal staff management (ISM)
2. Update userType to include course editor and staff. This aligns with the product requirement document on ISM
3. Refactored superadmin and admin into admin within database
4. Have confirmed that middleware works at redirecting in error case but not yet checked for happy path

Work in Progress:
1. Verify that session contains userType data that can be used for authorization
2. Update postman documents for internal APIs (need to check how to simulate sessions)
