### PR TITLE
fix: incorrect login text

### DIFF
--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -157,9 +157,9 @@ const LoginPage = ({ csrfToken, providers }: Props) => {
                   </Button>
                   <Box width='full' textAlign='center' mt={5}>
                     Don&#39;t have an account?{' '}
-                    <Link href='/login'>
+                    <Link href='/sign-up'>
                       <Text as='u' fontWeight='bold' color='#385600' _hover={{ cursor: 'pointer' }}>
-                        Log in
+                        Sign Up
                       </Text>
                     </Link>
                   </Box>


### PR DESCRIPTION

Login page currently redirects back to the same page if a user clicks on "Don't have an account? Log in"

<img width="566" alt="Screenshot 2023-09-21 at 10 53 03 PM" src="https://github.com/Project-Juniors-Club/jc-app/assets/73589885/ecdc8db9-6ae6-4bd6-a314-ea2bb7612368">